### PR TITLE
Updated error checking on deletePassword in C++

### DIFF
--- a/native/src/main.cpp
+++ b/native/src/main.cpp
@@ -47,7 +47,7 @@ EXPORTED bool deletePassword(const char* package, const char* service, const cha
 	keychain::Error* error = new keychain::Error();
 	keychain::deletePassword(package, service, user, *error);
 
-	if (error)
+	if (error->type != keychain::ErrorType::NoError)
 	{
 		lastError = error;
 		return false;


### PR DESCRIPTION
Updated error checking on deletePassword in C++ to avoid throwing an error in C# when there's no error